### PR TITLE
Update 1NCE zero touch provisioning

### DIFF
--- a/source/1nce_zero_touch_provisioning.c
+++ b/source/1nce_zero_touch_provisioning.c
@@ -183,9 +183,9 @@ static TlsTransportStatus_t nce_connect( NetworkContext_t * pxNetworkContext );
  *
  * @param[in] status: The status of previous operations.
  *
- * @param[in] status: The status of previous operations.
- *
  * @param[in] pxNetworkContext The parameter network context.
+ *
+ * @param[in] completeResponse: A buffer to collect complete onboarding response.
  *
  *
  * @return The status of the onboarding request.
@@ -450,6 +450,7 @@ static uint8_t nceReinitConnParams( char * completeResponse,
         return status;
     }
 
+    /* In the token we have now "ICCID" so we add 1 to start from the first number of ICCID */
     memcpy( nceThingName, token + 1, strSize );
     LogDebug( ( "Thing name is: %s.", nceThingName ) );
 
@@ -649,9 +650,14 @@ char * str_replace( char * orig,
                          &rangeEnd,
                          &rangeOriginalSize ) )
         {
+            LogDebug( ( "The size of the onboarding response is: %d\r\n",
+                        rangeOriginalSize ) );
+            return rangeOriginalSize;
         }
-
-        return rangeOriginalSize;
+        else
+        {
+            return EXIT_FAILURE;
+        }
     }
 /*-----------------------------------------------------------*/
 
@@ -697,6 +703,12 @@ char * str_replace( char * orig,
             if( rangeEnd == democonfigRANGE_SIZE )
             {
                 rangeOriginalSize = response_length( PART );
+
+                if( rangeOriginalSize == EXIT_FAILURE )
+                {
+                    LogError( ( "Failed to get complete onboarding response size." ) );
+                    return status;
+                }
             }
 
             if( recvBytes < 0 )

--- a/source/1nce_zero_touch_provisioning.c
+++ b/source/1nce_zero_touch_provisioning.c
@@ -165,6 +165,33 @@ static char PART[ RECV_BUFFER_LEN ];
  */
 static TlsTransportStatus_t nce_connect( NetworkContext_t * pxNetworkContext );
 
+/*-----------------------------------------------------------*/
+#ifdef democonfigRANGE_SIZE
+/**
+ * @brief The total byte length of the original response.
+ *
+ * @param[in] PART: A buffer to save received data (response header).
+ *
+ * @return the total byte of the original response.
+ */
+
+static int response_length(static char* PART);
+
+/**
+ * @brief request the onboarding service with a range defined in demo_config.
+ *
+ * @param[in] status: The status of previous operations.
+
+ * @param[in] status: The status of previous operations.
+ *
+ * @param[in] pxNetworkContext The parameter network context.
+ *
+ *
+ * @return The status of the onboarding request.
+ */
+static uint8_t onboarding_request(uint8_t status, NetworkContext_t* pxNetworkContext, char** completeResponse);
+#endif
+
 /**
  * @brief re-initialize MQTT connection information
  * from received onboarding response.
@@ -203,164 +230,168 @@ uint8_t nce_onboard( char ** pThingName,
                      char ** pClientCert,
                      char ** pPrvKey )
 {
-    uint8_t status = EXIT_FAILURE;
-    char completeResponse[ 5000 ];
+	uint8_t status = EXIT_FAILURE;
+	char completeResponse[ 5000 ];
 
-    memset( completeResponse, '\0', 5000 );
+	memset( completeResponse, '\0', 5000 );
 
-    LogInfo( ( "Start 1NCE device onboarding." ) );
+	LogInfo( ( "Start 1NCE device onboarding." ) );
 
-    /* Create TLS connection for onboarding request. */
-    TlsTransportStatus_t xNetworkStatus = nce_connect( &xNetworkContext );
+	/* Create TLS connection for onboarding request. */
+	TlsTransportStatus_t xNetworkStatus = nce_connect( &xNetworkContext );
 
-    if( TLS_TRANSPORT_SUCCESS != xNetworkStatus )
-    {
-        LogError( ( "Failed to connect to 1NCE server." ) );
-        return status;
-    }
+	if( TLS_TRANSPORT_SUCCESS != xNetworkStatus )
+	{
+		LogError( ( "Failed to connect to 1NCE server." ) );
+		return status;
+	}
 
-    /* Build onboarding request. */
-    char packetToSent[ 100 ];
+	/* Build onboarding request. */
+#ifdef democonfigRANGE_SIZE
+	status = onboarding_request(status, &xNetworkContext, &completeResponse);
+	if (status == EXIT_FAILURE) return status;
+#else
+	char packetToSent[100];
 
-    memset( packetToSent, '\0', 100 * sizeof( char ) );
-    sprintf( packetToSent, "GET /device-api/onboarding HTTP/1.1\r\n"
-                           "Host: %s\r\n"
-                           "Accept: text/csv\r\n\r\n", ONBOARDING_ENDPOINT );
-    LogInfo( ( "Send onboarding request:\r\n%.*s",
-               strlen( packetToSent ),
-               packetToSent ) );
+	memset( packetToSent, '\0', 100 * sizeof( char ) );
+	sprintf( packetToSent, "GET /device-api/onboarding HTTP/1.1\r\n"
+	         "Host: %s\r\n"
+	         "Accept: text/csv\r\n\r\n", ONBOARDING_ENDPOINT );
+	LogInfo( ( "Send onboarding request:\r\n%.*s",
+	           strlen( packetToSent ),
+	           packetToSent ) );
 
-    /* Send onboarding request. */
-    int32_t sentBytes = TLS_FreeRTOS_send( &xNetworkContext,
-                                           &packetToSent,
-                                           strlen( packetToSent ) );
+	/* Send onboarding request. */
+	int32_t sentBytes = TLS_FreeRTOS_send( &xNetworkContext,
+	                                       &packetToSent,
+	                                       strlen( packetToSent ) );
 
-    configASSERT( sentBytes > 0 );
+	configASSERT( sentBytes > 0 );
 
-    if( sentBytes <= 0 )
-    {
-        LogError( ( "Failed to send onboarding request." ) );
-        return status;
-    }
+	if( sentBytes <= 0 )
+	{
+		LogError( ( "Failed to send onboarding request." ) );
+		return status;
+	}
 
-    /* Receive onboarding response. */
-    int32_t recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
-                                           &PART[ 0 ],
-                                           RECV_BUFFER_LEN );
+	/* Receive onboarding response. */
+	int32_t recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
+	                                       &PART[ 0 ],
+	                                       RECV_BUFFER_LEN );
 
-    if( recvBytes < 0 )
-    {
-        LogError( ( "Failed to receive onboarding response." ) );
-        return status;
-    }
+	if( recvBytes < 0 )
+	{
+		LogError( ( "Failed to receive onboarding response." ) );
+		return status;
+	}
 
-    LogDebug( ( "Received raw response: %d bytes.", recvBytes ) );
-    LogDebug( ( "\r\n%.*s", recvBytes, PART ) );
-    strcat( completeResponse,
-            strstr( PART, "Express\r\n\r\n\"" ) + strlen( "Express\r\n\r\n\"" ) );
-    memset( PART, ( int8_t ) '\0', sizeof( PART ) );
+	LogDebug( ( "Received raw response: %d bytes.", recvBytes ) );
+	LogDebug( ( "\r\n%.*s", recvBytes, PART ) );
+	strcat( completeResponse,
+	        strstr( PART, "Express\r\n\r\n") + strlen( "Express\r\n\r\n" ) );
+	memset( PART, ( int8_t ) '\0', sizeof( PART ) );
 
-    while( recvBytes == RECV_BUFFER_LEN )
-    {
-        recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
-                                       &PART[ 0 ],
-                                       RECV_BUFFER_LEN );
+	while( recvBytes == RECV_BUFFER_LEN )
+	{
+		recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
+		                               &PART[ 0 ],
+		                               RECV_BUFFER_LEN );
 
-        if( recvBytes < 0 )
-        {
-            LogError( ( "Failed to receive onboarding response." ) );
-            return status;
-        }
+		if( recvBytes < 0 )
+		{
+			LogError( ( "Failed to receive onboarding response." ) );
+			return status;
+		}
 
-        LogDebug( ( "Received raw response: %d bytes.", strlen( PART ) ) );
-        LogDebug( ( "\r\n%.*s", strlen( PART ), PART ) );
-        strcat( completeResponse, PART );
-        memset( PART, ( int8_t ) '\0', sizeof( PART ) );
-    }
+		LogDebug( ( "Received raw response: %d bytes.", strlen( PART ) ) );
+		LogDebug( ( "\r\n%.*s", strlen( PART ), PART ) );
+		strcat( completeResponse, PART );
+		memset( PART, ( int8_t ) '\0', sizeof( PART ) );
+	}
+#endif
+	LogInfo( ( " Onboarding response is received." ) );
 
-    LogInfo( ( " Onboarding response is received." ) );
+	/* Disconnect onboarding TLS connection. */
+	TLS_FreeRTOS_Disconnect( &xNetworkContext );
 
-    /* Disconnect onboarding TLS connection. */
-    TLS_FreeRTOS_Disconnect( &xNetworkContext );
-
-    /* Re-initialize MQTT connection information with onboarding information. */
-    status = nceReinitConnParams( completeResponse,
-                                  pThingName,
-                                  pEndpoint,
-                                  pExampleTopic,
-                                  pRootCA,
-                                  pClientCert,
-                                  pPrvKey );
-    return status;
+	/* Re-initialize MQTT connection information with onboarding information. */
+	status = nceReinitConnParams( completeResponse,
+	                              pThingName,
+	                              pEndpoint,
+	                              pExampleTopic,
+	                              pRootCA,
+	                              pClientCert,
+	                              pPrvKey );
+	return status;
 }
 
 /*-----------------------------------------------------------*/
 
 TlsTransportStatus_t nce_connect( NetworkContext_t * pxNetworkContext )
 {
-    TlsTransportStatus_t xNetworkStatus = TLS_TRANSPORT_CONNECT_FAILURE;
-    BackoffAlgorithmStatus_t xBackoffAlgStatus = BackoffAlgorithmSuccess;
-    BackoffAlgorithmContext_t xReconnectParams;
-    uint16_t usNextRetryBackOff = 0U;
-    NetworkCredentials_t tNetworkCredentials = { 0 };
+	TlsTransportStatus_t xNetworkStatus = TLS_TRANSPORT_CONNECT_FAILURE;
+	BackoffAlgorithmStatus_t xBackoffAlgStatus = BackoffAlgorithmSuccess;
+	BackoffAlgorithmContext_t xReconnectParams;
+	uint16_t usNextRetryBackOff = 0U;
+	NetworkCredentials_t tNetworkCredentials = { 0 };
 
-    LogInfo( ( "Connecting to 1NCE server." ) );
+	LogInfo( ( "Connecting to 1NCE server." ) );
 
-    tNetworkCredentials.disableSni = democonfigDISABLE_SNI;
-    /* Set the credentials for establishing a TLS connection. */
-    tNetworkCredentials.pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
-    tNetworkCredentials.rootCaSize = sizeof( democonfigROOT_CA_PEM );
-    tNetworkCredentials.pClientCert = ( const unsigned char * ) democonfigCLIENT_CERTIFICATE_PEM;
-    tNetworkCredentials.clientCertSize = sizeof( democonfigCLIENT_CERTIFICATE_PEM );
-    tNetworkCredentials.pPrivateKey = ( const unsigned char * ) democonfigCLIENT_PRIVATE_KEY_PEM;
-    tNetworkCredentials.privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
+	tNetworkCredentials.disableSni = democonfigDISABLE_SNI;
+	/* Set the credentials for establishing a TLS connection. */
+	tNetworkCredentials.pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
+	tNetworkCredentials.rootCaSize = sizeof( democonfigROOT_CA_PEM );
+	tNetworkCredentials.pClientCert = ( const unsigned char * ) democonfigCLIENT_CERTIFICATE_PEM;
+	tNetworkCredentials.clientCertSize = sizeof( democonfigCLIENT_CERTIFICATE_PEM );
+	tNetworkCredentials.pPrivateKey = ( const unsigned char * ) democonfigCLIENT_PRIVATE_KEY_PEM;
+	tNetworkCredentials.privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
 
-    /* Initialize reconnect attempts and interval. */
-    BackoffAlgorithm_InitializeParams( &xReconnectParams,
-                                       mqttexampleRETRY_BACKOFF_BASE_MS,
-                                       mqttexampleRETRY_MAX_BACKOFF_DELAY_MS,
-                                       mqttexampleRETRY_MAX_ATTEMPTS );
+	/* Initialize reconnect attempts and interval. */
+	BackoffAlgorithm_InitializeParams( &xReconnectParams,
+	                                   mqttexampleRETRY_BACKOFF_BASE_MS,
+	                                   mqttexampleRETRY_MAX_BACKOFF_DELAY_MS,
+	                                   mqttexampleRETRY_MAX_ATTEMPTS );
 
-    /* Attempt to connect to 1NCE server. If connection fails, retry after
-     * a timeout. Timeout value will exponentially increase till maximum
-     * attempts are reached.
-     */
-    do
-    {
-        LogInfo( ( "Creating a TLS connection to %s:%u.",
-                   ONBOARDING_ENDPOINT,
-                   ONBOARDING_PORT ) );
-        /* Attempt to create a mutually authenticated TLS connection. */
-        xNetworkStatus = TLS_FreeRTOS_Connect( pxNetworkContext,
-                                               ONBOARDING_ENDPOINT,
-                                               ONBOARDING_PORT,
-                                               &tNetworkCredentials,
-                                               nceTRANSPORT_SEND_RECV_TIMEOUT_MS,
-                                               nceTRANSPORT_SEND_RECV_TIMEOUT_MS );
+	/* Attempt to connect to 1NCE server. If connection fails, retry after
+	 * a timeout. Timeout value will exponentially increase till maximum
+	 * attempts are reached.
+	 */
+	do
+	{
+		LogInfo( ( "Creating a TLS connection to %s:%u.",
+		           ONBOARDING_ENDPOINT,
+		           ONBOARDING_PORT ) );
+		/* Attempt to create a mutually authenticated TLS connection. */
+		xNetworkStatus = TLS_FreeRTOS_Connect( pxNetworkContext,
+		                                       ONBOARDING_ENDPOINT,
+		                                       ONBOARDING_PORT,
+		                                       &tNetworkCredentials,
+		                                       nceTRANSPORT_SEND_RECV_TIMEOUT_MS,
+		                                       nceTRANSPORT_SEND_RECV_TIMEOUT_MS );
 
-        if( xNetworkStatus != TLS_TRANSPORT_SUCCESS )
-        {
-            /* Generate a random number and calculate backoff value (in milliseconds) for
-             * the next connection retry.
-             * Note: It is recommended to seed the random number generator with a device-specific
-             * entropy source so that possibility of multiple devices retrying failed network operations
-             * at similar intervals can be avoided. */
-            xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &xReconnectParams, uxRand(), &usNextRetryBackOff );
+		if( xNetworkStatus != TLS_TRANSPORT_SUCCESS )
+		{
+			/* Generate a random number and calculate backoff value (in milliseconds) for
+			 * the next connection retry.
+			 * Note: It is recommended to seed the random number generator with a device-specific
+			 * entropy source so that possibility of multiple devices retrying failed network operations
+			 * at similar intervals can be avoided. */
+			xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &xReconnectParams, uxRand(), &usNextRetryBackOff );
 
-            if( xBackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
-            {
-                LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
-            }
-            else if( xBackoffAlgStatus == BackoffAlgorithmSuccess )
-            {
-                LogWarn( ( "Connection to the broker failed. "
-                           "Retrying connection with backoff and jitter." ) );
-                vTaskDelay( pdMS_TO_TICKS( usNextRetryBackOff ) );
-            }
-        }
-    } while ( ( xNetworkStatus != TLS_TRANSPORT_SUCCESS ) && ( xBackoffAlgStatus == BackoffAlgorithmSuccess ) );
+			if( xBackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
+			{
+				LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
+			}
+			else if( xBackoffAlgStatus == BackoffAlgorithmSuccess )
+			{
+				LogWarn( ( "Connection to the broker failed. "
+				           "Retrying connection with backoff and jitter." ) );
+				vTaskDelay( pdMS_TO_TICKS( usNextRetryBackOff ) );
+			}
+		}
+	} while ( ( xNetworkStatus != TLS_TRANSPORT_SUCCESS ) && ( xBackoffAlgStatus == BackoffAlgorithmSuccess ) );
 
-    return xNetworkStatus;
+	return xNetworkStatus;
 }
 
 /*-----------------------------------------------------------*/
@@ -373,169 +404,169 @@ static uint8_t nceReinitConnParams( char * completeResponse,
                                     char ** pClientCert,
                                     char ** pPrvKey )
 {
-    uint8_t status = EXIT_FAILURE;
+	uint8_t status = EXIT_FAILURE;
 
-    int i = 0;
-    int32_t strSize = 0;
-    int32_t offset = 0;
-    char find[] = "\\n";
-    char replaceWith[] = "\n";
-    char endKey[] = "-----END RSA PRIVATE KEY-----";
-    int32_t endKeyLen = sizeof( endKey );
-    char endCert[] = "-----END CERTIFICATE-----";
-    int32_t endCertLen = sizeof( endCert );
-    char * location = NULL;
+	int i = 0;
+	int32_t strSize = 0;
+	int32_t offset = 0;
+	char find[] = "\\n";
+	char replaceWith[] = "\n";
+	char endKey[] = "-----END RSA PRIVATE KEY-----";
+	int32_t endKeyLen = sizeof( endKey );
+	char endCert[] = "-----END CERTIFICATE-----";
+	int32_t endCertLen = sizeof( endCert );
+	char * location = NULL;
 
-    memset( nceThingName, '\0', sizeof( nceThingName ) );
-    memset( nceEndpoint, '\0', sizeof( nceEndpoint ) );
-    memset( nceExampleTopic, '\0', sizeof( nceExampleTopic ) );
-    memset( rootCA, '\0', sizeof( rootCA ) );
-    memset( clientCert, '\0', sizeof( clientCert ) );
-    memset( prvKey, '\0', sizeof( prvKey ) );
+	memset( nceThingName, '\0', sizeof( nceThingName ) );
+	memset( nceEndpoint, '\0', sizeof( nceEndpoint ) );
+	memset( nceExampleTopic, '\0', sizeof( nceExampleTopic ) );
+	memset( rootCA, '\0', sizeof( rootCA ) );
+	memset( clientCert, '\0', sizeof( clientCert ) );
+	memset( prvKey, '\0', sizeof( prvKey ) );
 
-    if( NULL == completeResponse )
-    {
-        LogError( ( "input argument is null." ) );
-        return status;
-    }
+	if( NULL == completeResponse )
+	{
+		LogError( ( "input argument is null." ) );
+		return status;
+	}
 
-    /* Get the first token. */
-    char * token = strtok( completeResponse, "," );
+	/* Get the first token. */
+	char * token = strtok( completeResponse, "," );
 
-    strSize = strlen( token );
-    token[ strSize - 1 ] = '\0';
+	strSize = strlen( token );
+	token[ strSize - 1 ] = '\0';
 
-    if( sizeof( nceThingName ) < strSize )
-    {
-        LogError( ( "nceThingName array size is not enough to hold incoming thing name." ) );
-        return status;
-    }
+	if( sizeof( nceThingName ) < strSize )
+	{
+		LogError( ( "nceThingName array size is not enough to hold incoming thing name." ) );
+		return status;
+	}
 
-    memcpy( nceThingName, token, strSize );
-    LogDebug( ( "Thing name is: %s.", nceThingName ) );
+	memcpy( nceThingName, token + 1, strSize );
+	LogDebug( ( "Thing name is: %s.", nceThingName ) );
 
-    /* Walk through other tokens. */
-    while( token != NULL )
-    {
-        token = strtok( NULL, "," );
+	/* Walk through other tokens. */
+	while( token != NULL )
+	{
+		token = strtok( NULL, "," );
 
-        if( i == 0 )
-        {
-            strSize = strlen( token ) - 2;
+		if( i == 0 )
+		{
+			strSize = strlen( token ) - 2;
 
-            if( sizeof( nceEndpoint ) < ( strSize + 1 ) )
-            {
-                LogError( ( "nceEndpoint array size is not enough to hold incoming endpoint." ) );
-                return status;
-            }
+			if( sizeof( nceEndpoint ) < ( strSize + 1 ) )
+			{
+				LogError( ( "nceEndpoint array size is not enough to hold incoming endpoint." ) );
+				return status;
+			}
 
-            memcpy( nceEndpoint, token + 1, strSize );
-            LogDebug( ( "IoTEndpoint is: %s.", nceEndpoint ) );
-        }
+			memcpy( nceEndpoint, token + 1, strSize );
+			LogDebug( ( "IoTEndpoint is: %s.", nceEndpoint ) );
+		}
 
-        /*
-         * if(i == 1) {
-         *  memcpy(amazonRootCaUrl, token, strlen(token));
-         * }
-         */
-        if( i == 2 )
-        {
-            /* Process root.pem. */
-            memcpy( PART, token + 1, strlen( token ) - 1 );
-            char * result = str_replace( PART, find, replaceWith );
-            memcpy( PART, result, strlen( PART ) );
-            vPortFree( result );
-            offset = ( int32_t ) ( &PART[ 0 ] );
-            location = strstr( PART, endCert );
-            strSize = ( int32_t ) location + endCertLen - offset;
-            PART[ strSize ] = '\0';
-            nceNetworkCredentials.rootCaSize = strSize + 1;
+		/*
+		 * if(i == 1) {
+		 *  memcpy(amazonRootCaUrl, token, strlen(token));
+		 * }
+		 */
+		if( i == 2 )
+		{
+			/* Process root.pem. */
+			memcpy( PART, token + 1, strlen( token ) - 1 );
+			char * result = str_replace( PART, find, replaceWith );
+			memcpy( PART, result, strlen( PART ) );
+			vPortFree( result );
+			offset = ( int32_t ) ( &PART[ 0 ] );
+			location = strstr( PART, endCert );
+			strSize = ( int32_t ) location + endCertLen - offset;
+			PART[ strSize ] = '\0';
+			nceNetworkCredentials.rootCaSize = strSize + 1;
 
-            if( sizeof( rootCA ) < ( strSize + 1 ) )
-            {
-                LogError( ( "rootCA array size is not enough to hold incoming root CA." ) );
-                return status;
-            }
+			if( sizeof( rootCA ) < ( strSize + 1 ) )
+			{
+				LogError( ( "rootCA array size is not enough to hold incoming root CA." ) );
+				return status;
+			}
 
-            memcpy( rootCA, PART, ( strSize + 1 ) );
-            ( void ) memset( &PART, ( int8_t ) '\0', sizeof( PART ) );
+			memcpy( rootCA, PART, ( strSize + 1 ) );
+			( void ) memset( &PART, ( int8_t ) '\0', sizeof( PART ) );
 
-            LogDebug( ( "\r\n%s", rootCA ) );
-        }
+			LogDebug( ( "\r\n%s", rootCA ) );
+		}
 
-        if( i == 3 )
-        {
-            /* Process client_cert.pem. */
-            memcpy( PART, token + 1, strlen( token ) - 1 );
-            char * result = str_replace( PART, find, replaceWith );
-            memcpy( PART, result, strlen( PART ) );
-            vPortFree( result );
-            offset = ( int32_t ) ( &PART[ 0 ] );
-            location = strstr( PART, endCert );
-            strSize = ( int32_t ) location + endCertLen - offset;
-            PART[ strSize ] = '\0';
+		if( i == 3 )
+		{
+			/* Process client_cert.pem. */
+			memcpy( PART, token + 1, strlen( token ) - 1 );
+			char * result = str_replace( PART, find, replaceWith );
+			memcpy( PART, result, strlen( PART ) );
+			vPortFree( result );
+			offset = ( int32_t ) ( &PART[ 0 ] );
+			location = strstr( PART, endCert );
+			strSize = ( int32_t ) location + endCertLen - offset;
+			PART[ strSize ] = '\0';
 
-            if( sizeof( clientCert ) < ( strSize + 1 ) )
-            {
-                LogError( ( "clientCert array size is not enough to hold incoming client certificate." ) );
-                return status;
-            }
+			if( sizeof( clientCert ) < ( strSize + 1 ) )
+			{
+				LogError( ( "clientCert array size is not enough to hold incoming client certificate." ) );
+				return status;
+			}
 
-            memcpy( clientCert, PART, ( strSize + 1 ) );
-            ( void ) memset( &PART, ( int8_t ) '\0', sizeof( PART ) );
+			memcpy( clientCert, PART, ( strSize + 1 ) );
+			( void ) memset( &PART, ( int8_t ) '\0', sizeof( PART ) );
 
-            LogDebug( ( "\r\n%s", clientCert ) );
-        }
+			LogDebug( ( "\r\n%s", clientCert ) );
+		}
 
-        if( i == 4 )
-        {
-            /* Process client_key.pem. */
-            memcpy( PART, token + 1, strlen( token ) - 1 );
-            char * result = str_replace( PART, find, replaceWith );
-            memcpy( PART, result, strlen( PART ) );
-            vPortFree( result );
-            offset = ( int32_t ) ( &PART[ 0 ] );
-            location = strstr( PART, endKey );
-            strSize = ( int32_t ) location + endKeyLen - offset;
-            PART[ strSize ] = '\0';
+		if( i == 4 )
+		{
+			/* Process client_key.pem. */
+			memcpy( PART, token + 1, strlen( token ) - 1 );
+			char * result = str_replace( PART, find, replaceWith );
+			memcpy( PART, result, strlen( PART ) );
+			vPortFree( result );
+			offset = ( int32_t ) ( &PART[ 0 ] );
+			location = strstr( PART, endKey );
+			strSize = ( int32_t ) location + endKeyLen - offset;
+			PART[ strSize ] = '\0';
 
-            if( sizeof( prvKey ) < ( strSize + 1 ) )
-            {
-                LogError( ( "prvKey size is not enough to hold incoming client private key." ) );
-                return status;
-            }
+			if( sizeof( prvKey ) < ( strSize + 1 ) )
+			{
+				LogError( ( "prvKey size is not enough to hold incoming client private key." ) );
+				return status;
+			}
 
-            memcpy( prvKey, PART, ( strSize + 1 ) );
-            ( void ) memset( &PART, ( int8_t ) '\0', sizeof( PART ) );
+			memcpy( prvKey, PART, ( strSize + 1 ) );
+			( void ) memset( &PART, ( int8_t ) '\0', sizeof( PART ) );
 
-            LogDebug( ( "\r\n%s", prvKey ) );
-        }
+			LogDebug( ( "\r\n%s", prvKey ) );
+		}
 
-        i++;
-    }
+		i++;
+	}
 
-    /* Initialize MQTT topic. */
-    strSize = strlen( nceThingName ) + strlen( "/example/topic" ) + 1;
+	/* Initialize MQTT topic. */
+	strSize = strlen( nceThingName ) + strlen( "/example/topic" ) + 1;
 
-    if( sizeof( nceExampleTopic ) < strSize )
-    {
-        LogError( ( "nceExampleTopic size is not enough to hold new example topic." ) );
-        return status;
-    }
+	if( sizeof( nceExampleTopic ) < strSize )
+	{
+		LogError( ( "nceExampleTopic size is not enough to hold new example topic." ) );
+		return status;
+	}
 
-    sprintf( nceExampleTopic, "%s/example/topic", nceThingName );
+	sprintf( nceExampleTopic, "%s/example/topic", nceThingName );
 
-    *pThingName = nceThingName;
-    *pEndpoint = nceEndpoint;
-    *pExampleTopic = nceExampleTopic;
-    *pRootCA = rootCA;
-    *pClientCert = clientCert;
-    *pPrvKey = prvKey;
+	*pThingName = nceThingName;
+	*pEndpoint = nceEndpoint;
+	*pExampleTopic = nceExampleTopic;
+	*pRootCA = rootCA;
+	*pClientCert = clientCert;
+	*pPrvKey = prvKey;
 
-    LogInfo( ( "Connection Info is re-initialized." ) );
+	LogInfo( ( "Connection Info is re-initialized." ) );
 
-    status = EXIT_SUCCESS;
-    return status;
+	status = EXIT_SUCCESS;
+	return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -544,57 +575,143 @@ char * str_replace( char * orig,
                     char * rep,
                     char * with )
 {
-    char * result = NULL;
-    char * ins = NULL;
-    char * tmp = NULL;
-    int lenRep = 0;
-    int lenWith = 0;
-    int lenFront = 0;
-    int count = 0;
+	char * result = NULL;
+	char * ins = NULL;
+	char * tmp = NULL;
+	int lenRep = 0;
+	int lenWith = 0;
+	int lenFront = 0;
+	int count = 0;
 
-    if( !orig || !rep )
-    {
-        return NULL;
-    }
+	if( !orig || !rep )
+	{
+		return NULL;
+	}
 
-    lenRep = strlen( rep );
+	lenRep = strlen( rep );
 
-    if( lenRep == 0 )
-    {
-        return NULL;
-    }
+	if( lenRep == 0 )
+	{
+		return NULL;
+	}
 
-    if( !with )
-    {
-        with = "";
-    }
+	if( !with )
+	{
+		with = "";
+	}
 
-    lenWith = strlen( with );
-    ins = orig;
+	lenWith = strlen( with );
+	ins = orig;
 
-    for( count = 0; tmp = strstr( ins, rep ); ++count )
-    {
-        ins = tmp + lenRep;
-    }
+	for( count = 0; tmp = strstr( ins, rep ); ++count )
+	{
+		ins = tmp + lenRep;
+	}
 
-    tmp = result = pvPortMalloc( strlen( orig ) + ( lenWith - lenRep ) * count + 1 );
+	tmp = result = pvPortMalloc( strlen( orig ) + ( lenWith - lenRep ) * count + 1 );
 
-    if( !result )
-    {
-        return NULL;
-    }
+	if( !result )
+	{
+		return NULL;
+	}
 
-    while( count-- )
-    {
-        ins = strstr( orig, rep );
-        lenFront = ins - orig;
-        tmp = strncpy( tmp, orig, lenFront ) + lenFront;
-        tmp = strcpy( tmp, with ) + lenWith;
-        orig += lenFront + lenRep;
-    }
+	while( count-- )
+	{
+		ins = strstr( orig, rep );
+		lenFront = ins - orig;
+		tmp = strncpy( tmp, orig, lenFront ) + lenFront;
+		tmp = strcpy( tmp, with ) + lenWith;
+		orig += lenFront + lenRep;
+	}
 
-    strcpy( tmp, orig );
-    return result;
+	strcpy( tmp, orig );
+	return result;
 }
 
+/*-----------------------------------------------------------*/
+#ifdef democonfigRANGE_SIZE
+static int response_length( char* PART ) {
+	int pch = strstr( PART, "bytes" );
+
+	int rangeStart, rangeEnd, rangeOriginalSize;
+	if (3 == sscanf( pch,
+	                 "%*[^0123456789]%d%*[^0123456789]%d%*[^0123456789]%d",
+	                 &rangeStart,
+	                 &rangeEnd,
+	                 &rangeOriginalSize));
+	return rangeOriginalSize;
+}
+/*-----------------------------------------------------------*/
+
+static uint8_t onboarding_request( uint8_t status, NetworkContext_t* pxNetworkContext, char** completeResponse ) {
+	char packetToSent[ 130 ];
+	int rangeStart = 0;
+	int rangeEnd = democonfigRANGE_SIZE;
+	int rangeOriginalSize;
+	memset( packetToSent, '\0', 130 * sizeof( char ) );
+	do {
+		sprintf(packetToSent, "GET /device-api/onboarding HTTP/1.1\r\n"
+		        "Host: %s\r\n"
+		        "Range: bytes=%d-%d\r\n"
+		        "Accept: text/csv\r\n\r\n", ONBOARDING_ENDPOINT, rangeStart, rangeEnd);
+		LogInfo( ( "Send onboarding request:\r\n%.*s",
+		           strlen(packetToSent),
+		           packetToSent ) );
+
+		/* Send onboarding request. */
+		int32_t sentBytes = TLS_FreeRTOS_send( &xNetworkContext,
+		                                       &packetToSent,
+		                                       strlen(packetToSent) );
+
+		configASSERT(sentBytes > 0);
+
+		if (sentBytes <= 0)
+		{
+			LogError(("Failed to send onboarding request."));
+			return status;
+		}
+
+		/* Receive onboarding response. */
+		int32_t recvBytes = TLS_FreeRTOS_recv(&xNetworkContext,
+		                                      &PART[0],
+		                                      RECV_BUFFER_LEN);
+		if (rangeEnd == democonfigRANGE_SIZE) {
+			rangeOriginalSize = response_length(PART);
+		}
+		if( recvBytes < 0 )
+		{
+			LogError( ( "Failed to receive onboarding response." ) );
+			return status;
+		}
+
+		LogDebug( ( "Received raw response: %d bytes.", recvBytes ) );
+		LogDebug( ( "\r\n%.*s", recvBytes, PART ) );
+		strcat(completeResponse,
+		       strstr(PART, "Express\r\n\r\n") + strlen("Express\r\n\r\n"));
+		memset(PART, (int8_t)'\0', sizeof(PART));
+
+		while (recvBytes == RECV_BUFFER_LEN)
+		{
+			recvBytes = TLS_FreeRTOS_recv(&xNetworkContext,
+			                              &PART[0],
+			                              RECV_BUFFER_LEN);
+
+			if (recvBytes < 0)
+			{
+				LogError( ( "Failed to receive onboarding response." ) );
+				return status;
+			}
+
+			LogDebug( ( "Received raw response: %d bytes.", strlen(PART) ) );
+			LogDebug( ( "\r\n%.*s", strlen(PART), PART ) );
+			strcat(completeResponse, PART);
+			memset(PART, (int8_t)'\0', sizeof(PART));
+		}
+		rangeStart = rangeEnd + 1;
+		rangeEnd += democonfigRANGE_SIZE;
+	} while( rangeStart < rangeOriginalSize );
+	status = EXIT_SUCCESS;
+	return status;
+}
+#endif
 /*-----------------------------------------------------------*/

--- a/source/1nce_zero_touch_provisioning.c
+++ b/source/1nce_zero_touch_provisioning.c
@@ -167,6 +167,7 @@ static TlsTransportStatus_t nce_connect( NetworkContext_t * pxNetworkContext );
 
 /*-----------------------------------------------------------*/
 #ifdef democonfigRANGE_SIZE
+
 /**
  * @brief The total byte length of the original response.
  *
@@ -175,13 +176,13 @@ static TlsTransportStatus_t nce_connect( NetworkContext_t * pxNetworkContext );
  * @return the total byte of the original response.
  */
 
-static int response_length(static char* PART);
+    static int response_length( static char * PART );
 
 /**
  * @brief request the onboarding service with a range defined in demo_config.
  *
  * @param[in] status: The status of previous operations.
-
+ *
  * @param[in] status: The status of previous operations.
  *
  * @param[in] pxNetworkContext The parameter network context.
@@ -189,7 +190,9 @@ static int response_length(static char* PART);
  *
  * @return The status of the onboarding request.
  */
-static uint8_t onboarding_request(uint8_t status, NetworkContext_t* pxNetworkContext, char** completeResponse);
+    static uint8_t onboarding_request( uint8_t status,
+                                       NetworkContext_t * pxNetworkContext,
+                                       char ** completeResponse );
 #endif
 
 /**
@@ -247,55 +250,41 @@ uint8_t nce_onboard( char ** pThingName,
     }
 
     /* Build onboarding request. */
-#ifdef democonfigRANGE_SIZE
-	status = onboarding_request(status, &xNetworkContext, &completeResponse);
-	if (status == EXIT_FAILURE) return status;
-#else
-    char packetToSent[ 100 ];
+    #ifdef democonfigRANGE_SIZE
+        status = onboarding_request( status, &xNetworkContext, &completeResponse );
 
-    memset( packetToSent, '\0', 100 * sizeof( char ) );
-    sprintf( packetToSent, "GET /device-api/onboarding HTTP/1.1\r\n"
-                           "Host: %s\r\n"
-                           "Accept: text/csv\r\n\r\n", ONBOARDING_ENDPOINT );
-    LogInfo( ( "Send onboarding request:\r\n%.*s",
-               strlen( packetToSent ),
-               packetToSent ) );
+        if( status == EXIT_FAILURE )
+        {
+            return status;
+        }
+    #else
+        char packetToSent[ 100 ];
 
-    /* Send onboarding request. */
-    int32_t sentBytes = TLS_FreeRTOS_send( &xNetworkContext,
-                                           &packetToSent,
-                                           strlen( packetToSent ) );
+        memset( packetToSent, '\0', 100 * sizeof( char ) );
+        sprintf( packetToSent, "GET /device-api/onboarding HTTP/1.1\r\n"
+                               "Host: %s\r\n"
+                               "Accept: text/csv\r\n\r\n", ONBOARDING_ENDPOINT );
+        LogInfo( ( "Send onboarding request:\r\n%.*s",
+                   strlen( packetToSent ),
+                   packetToSent ) );
 
-    configASSERT( sentBytes > 0 );
+        /* Send onboarding request. */
+        int32_t sentBytes = TLS_FreeRTOS_send( &xNetworkContext,
+                                               &packetToSent,
+                                               strlen( packetToSent ) );
 
-    if( sentBytes <= 0 )
-    {
-        LogError( ( "Failed to send onboarding request." ) );
-        return status;
-    }
+        configASSERT( sentBytes > 0 );
 
-    /* Receive onboarding response. */
-    int32_t recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
-                                           &PART[ 0 ],
-                                           RECV_BUFFER_LEN );
+        if( sentBytes <= 0 )
+        {
+            LogError( ( "Failed to send onboarding request." ) );
+            return status;
+        }
 
-    if( recvBytes < 0 )
-    {
-        LogError( ( "Failed to receive onboarding response." ) );
-        return status;
-    }
-
-    LogDebug( ( "Received raw response: %d bytes.", recvBytes ) );
-    LogDebug( ( "\r\n%.*s", recvBytes, PART ) );
-    strcat( completeResponse,
-            strstr( PART, "Express\r\n\r\n") + strlen( "Express\r\n\r\n" ) );
-    memset( PART, ( int8_t ) '\0', sizeof( PART ) );
-
-    while( recvBytes == RECV_BUFFER_LEN )
-    {
-        recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
-                                       &PART[ 0 ],
-                                       RECV_BUFFER_LEN );
+        /* Receive onboarding response. */
+        int32_t recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
+                                               &PART[ 0 ],
+                                               RECV_BUFFER_LEN );
 
         if( recvBytes < 0 )
         {
@@ -303,12 +292,30 @@ uint8_t nce_onboard( char ** pThingName,
             return status;
         }
 
-        LogDebug( ( "Received raw response: %d bytes.", strlen( PART ) ) );
-        LogDebug( ( "\r\n%.*s", strlen( PART ), PART ) );
-        strcat( completeResponse, PART );
+        LogDebug( ( "Received raw response: %d bytes.", recvBytes ) );
+        LogDebug( ( "\r\n%.*s", recvBytes, PART ) );
+        strcat( completeResponse,
+                strstr( PART, "Express\r\n\r\n" ) + strlen( "Express\r\n\r\n" ) );
         memset( PART, ( int8_t ) '\0', sizeof( PART ) );
-    }
-#endif
+
+        while( recvBytes == RECV_BUFFER_LEN )
+        {
+            recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
+                                           &PART[ 0 ],
+                                           RECV_BUFFER_LEN );
+
+            if( recvBytes < 0 )
+            {
+                LogError( ( "Failed to receive onboarding response." ) );
+                return status;
+            }
+
+            LogDebug( ( "Received raw response: %d bytes.", strlen( PART ) ) );
+            LogDebug( ( "\r\n%.*s", strlen( PART ), PART ) );
+            strcat( completeResponse, PART );
+            memset( PART, ( int8_t ) '\0', sizeof( PART ) );
+        }
+    #endif /* ifdef democonfigRANGE_SIZE */
 
     LogInfo( ( " Onboarding response is received." ) );
 
@@ -630,88 +637,104 @@ char * str_replace( char * orig,
 }
 /*-----------------------------------------------------------*/
 #ifdef democonfigRANGE_SIZE
-static int response_length( char* PART ) {
-    int pch = strstr( PART, "bytes" );
+    static int response_length( char * PART )
+    {
+        int pch = strstr( PART, "bytes" );
 
-    int rangeStart, rangeEnd, rangeOriginalSize;
-    if (3 == sscanf( pch,
-	                 "%*[^0123456789]%d%*[^0123456789]%d%*[^0123456789]%d",
-	                 &rangeStart,
-	                 &rangeEnd,
-    	             &rangeOriginalSize));
-    return rangeOriginalSize;
-}
+        int rangeStart, rangeEnd, rangeOriginalSize;
+
+        if( 3 == sscanf( pch,
+                         "%*[^0123456789]%d%*[^0123456789]%d%*[^0123456789]%d",
+                         &rangeStart,
+                         &rangeEnd,
+                         &rangeOriginalSize ) )
+        {
+        }
+
+        return rangeOriginalSize;
+    }
 /*-----------------------------------------------------------*/
 
-static uint8_t onboarding_request( uint8_t status, NetworkContext_t* pxNetworkContext, char** completeResponse ) {
-    char packetToSent[ 130 ];
-    int rangeStart = 0;
-    int rangeEnd = democonfigRANGE_SIZE;
-    int rangeOriginalSize;
-    memset( packetToSent, '\0', 130 * sizeof( char ) );
-    do {
-        sprintf(packetToSent, "GET /device-api/onboarding HTTP/1.1\r\n"
-                "Host: %s\r\n"
-                "Range: bytes=%d-%d\r\n"
-		        "Accept: text/csv\r\n\r\n", ONBOARDING_ENDPOINT, rangeStart, rangeEnd);
-		LogInfo( ( "Send onboarding request:\r\n%.*s",
-		           strlen(packetToSent),
-		           packetToSent ) );
+    static uint8_t onboarding_request( uint8_t status,
+                                       NetworkContext_t * pxNetworkContext,
+                                       char ** completeResponse )
+    {
+        char packetToSent[ 130 ];
+        int rangeStart = 0;
+        int rangeEnd = democonfigRANGE_SIZE;
+        int rangeOriginalSize;
 
-		/* Send onboarding request. */
-		int32_t sentBytes = TLS_FreeRTOS_send( &xNetworkContext,
-		                                       &packetToSent,
-		                                       strlen(packetToSent) );
+        memset( packetToSent, '\0', 130 * sizeof( char ) );
 
-		configASSERT(sentBytes > 0);
+        do
+        {
+            sprintf( packetToSent, "GET /device-api/onboarding HTTP/1.1\r\n"
+                                   "Host: %s\r\n"
+                                   "Range: bytes=%d-%d\r\n"
+                                   "Accept: text/csv\r\n\r\n", ONBOARDING_ENDPOINT, rangeStart, rangeEnd );
+            LogInfo( ( "Send onboarding request:\r\n%.*s",
+                       strlen( packetToSent ),
+                       packetToSent ) );
 
-		if (sentBytes <= 0)
-		{
-			LogError(("Failed to send onboarding request."));
-			return status;
-		}
+            /* Send onboarding request. */
+            int32_t sentBytes = TLS_FreeRTOS_send( &xNetworkContext,
+                                                   &packetToSent,
+                                                   strlen( packetToSent ) );
 
-		/* Receive onboarding response. */
-		int32_t recvBytes = TLS_FreeRTOS_recv(&xNetworkContext,
-		                                      &PART[0],
-		                                      RECV_BUFFER_LEN);
-		if (rangeEnd == democonfigRANGE_SIZE) {
-			rangeOriginalSize = response_length(PART);
-		}
-		if( recvBytes < 0 )
-		{
-			LogError( ( "Failed to receive onboarding response." ) );
-			return status;
-		}
+            configASSERT( sentBytes > 0 );
 
-		LogDebug( ( "Received raw response: %d bytes.", recvBytes ) );
-		LogDebug( ( "\r\n%.*s", recvBytes, PART ) );
-		strcat(completeResponse,
-		       strstr(PART, "Express\r\n\r\n") + strlen("Express\r\n\r\n"));
-		memset(PART, (int8_t)'\0', sizeof(PART));
+            if( sentBytes <= 0 )
+            {
+                LogError( ( "Failed to send onboarding request." ) );
+                return status;
+            }
 
-		while (recvBytes == RECV_BUFFER_LEN)
-		{
-			recvBytes = TLS_FreeRTOS_recv(&xNetworkContext,
-			                              &PART[0],
-			                              RECV_BUFFER_LEN);
+            /* Receive onboarding response. */
+            int32_t recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
+                                                   &PART[ 0 ],
+                                                   RECV_BUFFER_LEN );
 
-			if (recvBytes < 0)
-			{
-				LogError( ( "Failed to receive onboarding response." ) );
-				return status;
-			}
+            if( rangeEnd == democonfigRANGE_SIZE )
+            {
+                rangeOriginalSize = response_length( PART );
+            }
 
-			LogDebug( ( "Received raw response: %d bytes.", strlen(PART) ) );
-			LogDebug( ( "\r\n%.*s", strlen(PART), PART ) );
-			strcat(completeResponse, PART);
-			memset(PART, (int8_t)'\0', sizeof(PART));
-		}
-		rangeStart = rangeEnd + 1;
-		rangeEnd += democonfigRANGE_SIZE;
-	} while( rangeStart < rangeOriginalSize );
-	status = EXIT_SUCCESS;
-	return status;
-}
-#endif
+            if( recvBytes < 0 )
+            {
+                LogError( ( "Failed to receive onboarding response." ) );
+                return status;
+            }
+
+            LogDebug( ( "Received raw response: %d bytes.", recvBytes ) );
+            LogDebug( ( "\r\n%.*s", recvBytes, PART ) );
+            strcat( completeResponse,
+                    strstr( PART, "Express\r\n\r\n" ) + strlen( "Express\r\n\r\n" ) );
+            memset( PART, ( int8_t ) '\0', sizeof( PART ) );
+
+            while( recvBytes == RECV_BUFFER_LEN )
+            {
+                recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
+                                               &PART[ 0 ],
+                                               RECV_BUFFER_LEN );
+
+                if( recvBytes < 0 )
+                {
+                    LogError( ( "Failed to receive onboarding response." ) );
+                    return status;
+                }
+
+                LogDebug( ( "Received raw response: %d bytes.", strlen( PART ) ) );
+                LogDebug( ( "\r\n%.*s", strlen( PART ), PART ) );
+                strcat( completeResponse, PART );
+                memset( PART, ( int8_t ) '\0', sizeof( PART ) );
+            }
+
+            rangeStart = rangeEnd + 1;
+            rangeEnd += democonfigRANGE_SIZE;
+        } while( rangeStart < rangeOriginalSize );
+
+        status = EXIT_SUCCESS;
+        return status;
+    }
+#endif /* ifdef democonfigRANGE_SIZE */
 /*-----------------------------------------------------------*/

--- a/source/1nce_zero_touch_provisioning.c
+++ b/source/1nce_zero_touch_provisioning.c
@@ -230,168 +230,169 @@ uint8_t nce_onboard( char ** pThingName,
                      char ** pClientCert,
                      char ** pPrvKey )
 {
-	uint8_t status = EXIT_FAILURE;
-	char completeResponse[ 5000 ];
+    uint8_t status = EXIT_FAILURE;
+    char completeResponse[ 5000 ];
 
-	memset( completeResponse, '\0', 5000 );
+    memset( completeResponse, '\0', 5000 );
 
-	LogInfo( ( "Start 1NCE device onboarding." ) );
+    LogInfo( ( "Start 1NCE device onboarding." ) );
 
-	/* Create TLS connection for onboarding request. */
-	TlsTransportStatus_t xNetworkStatus = nce_connect( &xNetworkContext );
+    /* Create TLS connection for onboarding request. */
+    TlsTransportStatus_t xNetworkStatus = nce_connect( &xNetworkContext );
 
-	if( TLS_TRANSPORT_SUCCESS != xNetworkStatus )
-	{
-		LogError( ( "Failed to connect to 1NCE server." ) );
-		return status;
-	}
+    if( TLS_TRANSPORT_SUCCESS != xNetworkStatus )
+    {
+        LogError( ( "Failed to connect to 1NCE server." ) );
+        return status;
+    }
 
-	/* Build onboarding request. */
+    /* Build onboarding request. */
 #ifdef democonfigRANGE_SIZE
 	status = onboarding_request(status, &xNetworkContext, &completeResponse);
 	if (status == EXIT_FAILURE) return status;
 #else
-	char packetToSent[100];
+    char packetToSent[ 100 ];
 
-	memset( packetToSent, '\0', 100 * sizeof( char ) );
-	sprintf( packetToSent, "GET /device-api/onboarding HTTP/1.1\r\n"
-	         "Host: %s\r\n"
-	         "Accept: text/csv\r\n\r\n", ONBOARDING_ENDPOINT );
-	LogInfo( ( "Send onboarding request:\r\n%.*s",
-	           strlen( packetToSent ),
-	           packetToSent ) );
+    memset( packetToSent, '\0', 100 * sizeof( char ) );
+    sprintf( packetToSent, "GET /device-api/onboarding HTTP/1.1\r\n"
+                           "Host: %s\r\n"
+                           "Accept: text/csv\r\n\r\n", ONBOARDING_ENDPOINT );
+    LogInfo( ( "Send onboarding request:\r\n%.*s",
+               strlen( packetToSent ),
+               packetToSent ) );
 
-	/* Send onboarding request. */
-	int32_t sentBytes = TLS_FreeRTOS_send( &xNetworkContext,
-	                                       &packetToSent,
-	                                       strlen( packetToSent ) );
+    /* Send onboarding request. */
+    int32_t sentBytes = TLS_FreeRTOS_send( &xNetworkContext,
+                                           &packetToSent,
+                                           strlen( packetToSent ) );
 
-	configASSERT( sentBytes > 0 );
+    configASSERT( sentBytes > 0 );
 
-	if( sentBytes <= 0 )
-	{
-		LogError( ( "Failed to send onboarding request." ) );
-		return status;
-	}
+    if( sentBytes <= 0 )
+    {
+        LogError( ( "Failed to send onboarding request." ) );
+        return status;
+    }
 
-	/* Receive onboarding response. */
-	int32_t recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
-	                                       &PART[ 0 ],
-	                                       RECV_BUFFER_LEN );
+    /* Receive onboarding response. */
+    int32_t recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
+                                           &PART[ 0 ],
+                                           RECV_BUFFER_LEN );
 
-	if( recvBytes < 0 )
-	{
-		LogError( ( "Failed to receive onboarding response." ) );
-		return status;
-	}
+    if( recvBytes < 0 )
+    {
+        LogError( ( "Failed to receive onboarding response." ) );
+        return status;
+    }
 
-	LogDebug( ( "Received raw response: %d bytes.", recvBytes ) );
-	LogDebug( ( "\r\n%.*s", recvBytes, PART ) );
-	strcat( completeResponse,
-	        strstr( PART, "Express\r\n\r\n") + strlen( "Express\r\n\r\n" ) );
-	memset( PART, ( int8_t ) '\0', sizeof( PART ) );
+    LogDebug( ( "Received raw response: %d bytes.", recvBytes ) );
+    LogDebug( ( "\r\n%.*s", recvBytes, PART ) );
+    strcat( completeResponse,
+            strstr( PART, "Express\r\n\r\n") + strlen( "Express\r\n\r\n" ) );
+    memset( PART, ( int8_t ) '\0', sizeof( PART ) );
 
-	while( recvBytes == RECV_BUFFER_LEN )
-	{
-		recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
-		                               &PART[ 0 ],
-		                               RECV_BUFFER_LEN );
+    while( recvBytes == RECV_BUFFER_LEN )
+    {
+        recvBytes = TLS_FreeRTOS_recv( &xNetworkContext,
+                                       &PART[ 0 ],
+                                       RECV_BUFFER_LEN );
 
-		if( recvBytes < 0 )
-		{
-			LogError( ( "Failed to receive onboarding response." ) );
-			return status;
-		}
+        if( recvBytes < 0 )
+        {
+            LogError( ( "Failed to receive onboarding response." ) );
+            return status;
+        }
 
-		LogDebug( ( "Received raw response: %d bytes.", strlen( PART ) ) );
-		LogDebug( ( "\r\n%.*s", strlen( PART ), PART ) );
-		strcat( completeResponse, PART );
-		memset( PART, ( int8_t ) '\0', sizeof( PART ) );
-	}
+        LogDebug( ( "Received raw response: %d bytes.", strlen( PART ) ) );
+        LogDebug( ( "\r\n%.*s", strlen( PART ), PART ) );
+        strcat( completeResponse, PART );
+        memset( PART, ( int8_t ) '\0', sizeof( PART ) );
+    }
 #endif
-	LogInfo( ( " Onboarding response is received." ) );
 
-	/* Disconnect onboarding TLS connection. */
-	TLS_FreeRTOS_Disconnect( &xNetworkContext );
+    LogInfo( ( " Onboarding response is received." ) );
 
-	/* Re-initialize MQTT connection information with onboarding information. */
-	status = nceReinitConnParams( completeResponse,
-	                              pThingName,
-	                              pEndpoint,
-	                              pExampleTopic,
-	                              pRootCA,
-	                              pClientCert,
-	                              pPrvKey );
-	return status;
+    /* Disconnect onboarding TLS connection. */
+    TLS_FreeRTOS_Disconnect( &xNetworkContext );
+
+    /* Re-initialize MQTT connection information with onboarding information. */
+    status = nceReinitConnParams( completeResponse,
+                                  pThingName,
+                                  pEndpoint,
+                                  pExampleTopic,
+                                  pRootCA,
+                                  pClientCert,
+                                  pPrvKey );
+    return status;
 }
 
 /*-----------------------------------------------------------*/
 
 TlsTransportStatus_t nce_connect( NetworkContext_t * pxNetworkContext )
 {
-	TlsTransportStatus_t xNetworkStatus = TLS_TRANSPORT_CONNECT_FAILURE;
-	BackoffAlgorithmStatus_t xBackoffAlgStatus = BackoffAlgorithmSuccess;
-	BackoffAlgorithmContext_t xReconnectParams;
-	uint16_t usNextRetryBackOff = 0U;
-	NetworkCredentials_t tNetworkCredentials = { 0 };
+    TlsTransportStatus_t xNetworkStatus = TLS_TRANSPORT_CONNECT_FAILURE;
+    BackoffAlgorithmStatus_t xBackoffAlgStatus = BackoffAlgorithmSuccess;
+    BackoffAlgorithmContext_t xReconnectParams;
+    uint16_t usNextRetryBackOff = 0U;
+    NetworkCredentials_t tNetworkCredentials = { 0 };
 
-	LogInfo( ( "Connecting to 1NCE server." ) );
+    LogInfo( ( "Connecting to 1NCE server." ) );
 
-	tNetworkCredentials.disableSni = democonfigDISABLE_SNI;
-	/* Set the credentials for establishing a TLS connection. */
-	tNetworkCredentials.pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
-	tNetworkCredentials.rootCaSize = sizeof( democonfigROOT_CA_PEM );
-	tNetworkCredentials.pClientCert = ( const unsigned char * ) democonfigCLIENT_CERTIFICATE_PEM;
-	tNetworkCredentials.clientCertSize = sizeof( democonfigCLIENT_CERTIFICATE_PEM );
-	tNetworkCredentials.pPrivateKey = ( const unsigned char * ) democonfigCLIENT_PRIVATE_KEY_PEM;
-	tNetworkCredentials.privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
+    tNetworkCredentials.disableSni = democonfigDISABLE_SNI;
+    /* Set the credentials for establishing a TLS connection. */
+    tNetworkCredentials.pRootCa = ( const unsigned char * ) democonfigROOT_CA_PEM;
+    tNetworkCredentials.rootCaSize = sizeof( democonfigROOT_CA_PEM );
+    tNetworkCredentials.pClientCert = ( const unsigned char * ) democonfigCLIENT_CERTIFICATE_PEM;
+    tNetworkCredentials.clientCertSize = sizeof( democonfigCLIENT_CERTIFICATE_PEM );
+    tNetworkCredentials.pPrivateKey = ( const unsigned char * ) democonfigCLIENT_PRIVATE_KEY_PEM;
+    tNetworkCredentials.privateKeySize = sizeof( democonfigCLIENT_PRIVATE_KEY_PEM );
 
-	/* Initialize reconnect attempts and interval. */
-	BackoffAlgorithm_InitializeParams( &xReconnectParams,
-	                                   mqttexampleRETRY_BACKOFF_BASE_MS,
-	                                   mqttexampleRETRY_MAX_BACKOFF_DELAY_MS,
-	                                   mqttexampleRETRY_MAX_ATTEMPTS );
+    /* Initialize reconnect attempts and interval. */
+    BackoffAlgorithm_InitializeParams( &xReconnectParams,
+                                       mqttexampleRETRY_BACKOFF_BASE_MS,
+                                       mqttexampleRETRY_MAX_BACKOFF_DELAY_MS,
+                                       mqttexampleRETRY_MAX_ATTEMPTS );
 
-	/* Attempt to connect to 1NCE server. If connection fails, retry after
-	 * a timeout. Timeout value will exponentially increase till maximum
-	 * attempts are reached.
-	 */
-	do
-	{
-		LogInfo( ( "Creating a TLS connection to %s:%u.",
-		           ONBOARDING_ENDPOINT,
-		           ONBOARDING_PORT ) );
-		/* Attempt to create a mutually authenticated TLS connection. */
-		xNetworkStatus = TLS_FreeRTOS_Connect( pxNetworkContext,
-		                                       ONBOARDING_ENDPOINT,
-		                                       ONBOARDING_PORT,
-		                                       &tNetworkCredentials,
-		                                       nceTRANSPORT_SEND_RECV_TIMEOUT_MS,
-		                                       nceTRANSPORT_SEND_RECV_TIMEOUT_MS );
+    /* Attempt to connect to 1NCE server. If connection fails, retry after
+     * a timeout. Timeout value will exponentially increase till maximum
+     * attempts are reached.
+     */
+    do
+    {
+        LogInfo( ( "Creating a TLS connection to %s:%u.",
+                   ONBOARDING_ENDPOINT,
+                   ONBOARDING_PORT ) );
+        /* Attempt to create a mutually authenticated TLS connection. */
+        xNetworkStatus = TLS_FreeRTOS_Connect( pxNetworkContext,
+                                               ONBOARDING_ENDPOINT,
+                                               ONBOARDING_PORT,
+                                               &tNetworkCredentials,
+                                               nceTRANSPORT_SEND_RECV_TIMEOUT_MS,
+                                               nceTRANSPORT_SEND_RECV_TIMEOUT_MS );
 
-		if( xNetworkStatus != TLS_TRANSPORT_SUCCESS )
-		{
-			/* Generate a random number and calculate backoff value (in milliseconds) for
-			 * the next connection retry.
-			 * Note: It is recommended to seed the random number generator with a device-specific
-			 * entropy source so that possibility of multiple devices retrying failed network operations
-			 * at similar intervals can be avoided. */
-			xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &xReconnectParams, uxRand(), &usNextRetryBackOff );
+        if( xNetworkStatus != TLS_TRANSPORT_SUCCESS )
+        {
+            /* Generate a random number and calculate backoff value (in milliseconds) for
+             * the next connection retry.
+             * Note: It is recommended to seed the random number generator with a device-specific
+             * entropy source so that possibility of multiple devices retrying failed network operations
+             * at similar intervals can be avoided. */
+            xBackoffAlgStatus = BackoffAlgorithm_GetNextBackoff( &xReconnectParams, uxRand(), &usNextRetryBackOff );
 
-			if( xBackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
-			{
-				LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
-			}
-			else if( xBackoffAlgStatus == BackoffAlgorithmSuccess )
-			{
-				LogWarn( ( "Connection to the broker failed. "
-				           "Retrying connection with backoff and jitter." ) );
-				vTaskDelay( pdMS_TO_TICKS( usNextRetryBackOff ) );
-			}
-		}
-	} while ( ( xNetworkStatus != TLS_TRANSPORT_SUCCESS ) && ( xBackoffAlgStatus == BackoffAlgorithmSuccess ) );
+            if( xBackoffAlgStatus == BackoffAlgorithmRetriesExhausted )
+            {
+                LogError( ( "Connection to the broker failed, all attempts exhausted." ) );
+            }
+            else if( xBackoffAlgStatus == BackoffAlgorithmSuccess )
+            {
+                LogWarn( ( "Connection to the broker failed. "
+                           "Retrying connection with backoff and jitter." ) );
+                vTaskDelay( pdMS_TO_TICKS( usNextRetryBackOff ) );
+            }
+        }
+    } while ( ( xNetworkStatus != TLS_TRANSPORT_SUCCESS ) && ( xBackoffAlgStatus == BackoffAlgorithmSuccess ) );
 
-	return xNetworkStatus;
+    return xNetworkStatus;
 }
 
 /*-----------------------------------------------------------*/
@@ -404,169 +405,169 @@ static uint8_t nceReinitConnParams( char * completeResponse,
                                     char ** pClientCert,
                                     char ** pPrvKey )
 {
-	uint8_t status = EXIT_FAILURE;
+    uint8_t status = EXIT_FAILURE;
 
-	int i = 0;
-	int32_t strSize = 0;
-	int32_t offset = 0;
-	char find[] = "\\n";
-	char replaceWith[] = "\n";
-	char endKey[] = "-----END RSA PRIVATE KEY-----";
-	int32_t endKeyLen = sizeof( endKey );
-	char endCert[] = "-----END CERTIFICATE-----";
-	int32_t endCertLen = sizeof( endCert );
-	char * location = NULL;
+    int i = 0;
+    int32_t strSize = 0;
+    int32_t offset = 0;
+    char find[] = "\\n";
+    char replaceWith[] = "\n";
+    char endKey[] = "-----END RSA PRIVATE KEY-----";
+    int32_t endKeyLen = sizeof( endKey );
+    char endCert[] = "-----END CERTIFICATE-----";
+    int32_t endCertLen = sizeof( endCert );
+    char * location = NULL;
 
-	memset( nceThingName, '\0', sizeof( nceThingName ) );
-	memset( nceEndpoint, '\0', sizeof( nceEndpoint ) );
-	memset( nceExampleTopic, '\0', sizeof( nceExampleTopic ) );
-	memset( rootCA, '\0', sizeof( rootCA ) );
-	memset( clientCert, '\0', sizeof( clientCert ) );
-	memset( prvKey, '\0', sizeof( prvKey ) );
+    memset( nceThingName, '\0', sizeof( nceThingName ) );
+    memset( nceEndpoint, '\0', sizeof( nceEndpoint ) );
+    memset( nceExampleTopic, '\0', sizeof( nceExampleTopic ) );
+    memset( rootCA, '\0', sizeof( rootCA ) );
+    memset( clientCert, '\0', sizeof( clientCert ) );
+    memset( prvKey, '\0', sizeof( prvKey ) );
 
-	if( NULL == completeResponse )
-	{
-		LogError( ( "input argument is null." ) );
-		return status;
-	}
+    if( NULL == completeResponse )
+    {
+        LogError( ( "input argument is null." ) );
+        return status;
+    }
 
-	/* Get the first token. */
-	char * token = strtok( completeResponse, "," );
+    /* Get the first token. */
+    char * token = strtok( completeResponse, "," );
 
-	strSize = strlen( token );
-	token[ strSize - 1 ] = '\0';
+    strSize = strlen( token );
+    token[ strSize - 1 ] = '\0';
 
-	if( sizeof( nceThingName ) < strSize )
-	{
-		LogError( ( "nceThingName array size is not enough to hold incoming thing name." ) );
-		return status;
-	}
+    if( sizeof( nceThingName ) < strSize )
+    {
+        LogError( ( "nceThingName array size is not enough to hold incoming thing name." ) );
+        return status;
+    }
 
-	memcpy( nceThingName, token + 1, strSize );
-	LogDebug( ( "Thing name is: %s.", nceThingName ) );
+    memcpy( nceThingName, token + 1, strSize );
+    LogDebug( ( "Thing name is: %s.", nceThingName ) );
 
-	/* Walk through other tokens. */
-	while( token != NULL )
-	{
-		token = strtok( NULL, "," );
+    /* Walk through other tokens. */
+    while( token != NULL )
+    {
+        token = strtok( NULL, "," );
 
-		if( i == 0 )
-		{
-			strSize = strlen( token ) - 2;
+        if( i == 0 )
+        {
+            strSize = strlen( token ) - 2;
 
-			if( sizeof( nceEndpoint ) < ( strSize + 1 ) )
-			{
-				LogError( ( "nceEndpoint array size is not enough to hold incoming endpoint." ) );
-				return status;
-			}
+            if( sizeof( nceEndpoint ) < ( strSize + 1 ) )
+            {
+                LogError( ( "nceEndpoint array size is not enough to hold incoming endpoint." ) );
+                return status;
+            }
 
-			memcpy( nceEndpoint, token + 1, strSize );
-			LogDebug( ( "IoTEndpoint is: %s.", nceEndpoint ) );
-		}
+            memcpy( nceEndpoint, token + 1, strSize );
+            LogDebug( ( "IoTEndpoint is: %s.", nceEndpoint ) );
+        }
 
-		/*
-		 * if(i == 1) {
-		 *  memcpy(amazonRootCaUrl, token, strlen(token));
-		 * }
-		 */
-		if( i == 2 )
-		{
-			/* Process root.pem. */
-			memcpy( PART, token + 1, strlen( token ) - 1 );
-			char * result = str_replace( PART, find, replaceWith );
-			memcpy( PART, result, strlen( PART ) );
-			vPortFree( result );
-			offset = ( int32_t ) ( &PART[ 0 ] );
-			location = strstr( PART, endCert );
-			strSize = ( int32_t ) location + endCertLen - offset;
-			PART[ strSize ] = '\0';
-			nceNetworkCredentials.rootCaSize = strSize + 1;
+        /*
+         * if(i == 1) {
+         *  memcpy(amazonRootCaUrl, token, strlen(token));
+         * }
+         */
+        if( i == 2 )
+        {
+            /* Process root.pem. */
+            memcpy( PART, token + 1, strlen( token ) - 1 );
+            char * result = str_replace( PART, find, replaceWith );
+            memcpy( PART, result, strlen( PART ) );
+            vPortFree( result );
+            offset = ( int32_t ) ( &PART[ 0 ] );
+            location = strstr( PART, endCert );
+            strSize = ( int32_t ) location + endCertLen - offset;
+            PART[ strSize ] = '\0';
+            nceNetworkCredentials.rootCaSize = strSize + 1;
 
-			if( sizeof( rootCA ) < ( strSize + 1 ) )
-			{
-				LogError( ( "rootCA array size is not enough to hold incoming root CA." ) );
-				return status;
-			}
+            if( sizeof( rootCA ) < ( strSize + 1 ) )
+            {
+                LogError( ( "rootCA array size is not enough to hold incoming root CA." ) );
+                return status;
+            }
 
-			memcpy( rootCA, PART, ( strSize + 1 ) );
-			( void ) memset( &PART, ( int8_t ) '\0', sizeof( PART ) );
+            memcpy( rootCA, PART, ( strSize + 1 ) );
+            ( void ) memset( &PART, ( int8_t ) '\0', sizeof( PART ) );
 
-			LogDebug( ( "\r\n%s", rootCA ) );
-		}
+            LogDebug( ( "\r\n%s", rootCA ) );
+        }
 
-		if( i == 3 )
-		{
-			/* Process client_cert.pem. */
-			memcpy( PART, token + 1, strlen( token ) - 1 );
-			char * result = str_replace( PART, find, replaceWith );
-			memcpy( PART, result, strlen( PART ) );
-			vPortFree( result );
-			offset = ( int32_t ) ( &PART[ 0 ] );
-			location = strstr( PART, endCert );
-			strSize = ( int32_t ) location + endCertLen - offset;
-			PART[ strSize ] = '\0';
+        if( i == 3 )
+        {
+            /* Process client_cert.pem. */
+            memcpy( PART, token + 1, strlen( token ) - 1 );
+            char * result = str_replace( PART, find, replaceWith );
+            memcpy( PART, result, strlen( PART ) );
+            vPortFree( result );
+            offset = ( int32_t ) ( &PART[ 0 ] );
+            location = strstr( PART, endCert );
+            strSize = ( int32_t ) location + endCertLen - offset;
+            PART[ strSize ] = '\0';
 
-			if( sizeof( clientCert ) < ( strSize + 1 ) )
-			{
-				LogError( ( "clientCert array size is not enough to hold incoming client certificate." ) );
-				return status;
-			}
+            if( sizeof( clientCert ) < ( strSize + 1 ) )
+            {
+                LogError( ( "clientCert array size is not enough to hold incoming client certificate." ) );
+                return status;
+            }
 
-			memcpy( clientCert, PART, ( strSize + 1 ) );
-			( void ) memset( &PART, ( int8_t ) '\0', sizeof( PART ) );
+            memcpy( clientCert, PART, ( strSize + 1 ) );
+            ( void ) memset( &PART, ( int8_t ) '\0', sizeof( PART ) );
 
-			LogDebug( ( "\r\n%s", clientCert ) );
-		}
+            LogDebug( ( "\r\n%s", clientCert ) );
+        }
 
-		if( i == 4 )
-		{
-			/* Process client_key.pem. */
-			memcpy( PART, token + 1, strlen( token ) - 1 );
-			char * result = str_replace( PART, find, replaceWith );
-			memcpy( PART, result, strlen( PART ) );
-			vPortFree( result );
-			offset = ( int32_t ) ( &PART[ 0 ] );
-			location = strstr( PART, endKey );
-			strSize = ( int32_t ) location + endKeyLen - offset;
-			PART[ strSize ] = '\0';
+        if( i == 4 )
+        {
+            /* Process client_key.pem. */
+            memcpy( PART, token + 1, strlen( token ) - 1 );
+            char * result = str_replace( PART, find, replaceWith );
+            memcpy( PART, result, strlen( PART ) );
+            vPortFree( result );
+            offset = ( int32_t ) ( &PART[ 0 ] );
+            location = strstr( PART, endKey );
+            strSize = ( int32_t ) location + endKeyLen - offset;
+            PART[ strSize ] = '\0';
 
-			if( sizeof( prvKey ) < ( strSize + 1 ) )
-			{
-				LogError( ( "prvKey size is not enough to hold incoming client private key." ) );
-				return status;
-			}
+            if( sizeof( prvKey ) < ( strSize + 1 ) )
+            {
+                LogError( ( "prvKey size is not enough to hold incoming client private key." ) );
+                return status;
+            }
 
-			memcpy( prvKey, PART, ( strSize + 1 ) );
-			( void ) memset( &PART, ( int8_t ) '\0', sizeof( PART ) );
+            memcpy( prvKey, PART, ( strSize + 1 ) );
+            ( void ) memset( &PART, ( int8_t ) '\0', sizeof( PART ) );
 
-			LogDebug( ( "\r\n%s", prvKey ) );
-		}
+            LogDebug( ( "\r\n%s", prvKey ) );
+        }
 
-		i++;
-	}
+        i++;
+    }
 
-	/* Initialize MQTT topic. */
-	strSize = strlen( nceThingName ) + strlen( "/example/topic" ) + 1;
+    /* Initialize MQTT topic. */
+    strSize = strlen( nceThingName ) + strlen( "/example/topic" ) + 1;
 
-	if( sizeof( nceExampleTopic ) < strSize )
-	{
-		LogError( ( "nceExampleTopic size is not enough to hold new example topic." ) );
-		return status;
-	}
+    if( sizeof( nceExampleTopic ) < strSize )
+    {
+        LogError( ( "nceExampleTopic size is not enough to hold new example topic." ) );
+        return status;
+    }
 
-	sprintf( nceExampleTopic, "%s/example/topic", nceThingName );
+    sprintf( nceExampleTopic, "%s/example/topic", nceThingName );
 
-	*pThingName = nceThingName;
-	*pEndpoint = nceEndpoint;
-	*pExampleTopic = nceExampleTopic;
-	*pRootCA = rootCA;
-	*pClientCert = clientCert;
-	*pPrvKey = prvKey;
+    *pThingName = nceThingName;
+    *pEndpoint = nceEndpoint;
+    *pExampleTopic = nceExampleTopic;
+    *pRootCA = rootCA;
+    *pClientCert = clientCert;
+    *pPrvKey = prvKey;
 
-	LogInfo( ( "Connection Info is re-initialized." ) );
+    LogInfo( ( "Connection Info is re-initialized." ) );
 
-	status = EXIT_SUCCESS;
-	return status;
+    status = EXIT_SUCCESS;
+    return status;
 }
 
 /*-----------------------------------------------------------*/
@@ -575,84 +576,83 @@ char * str_replace( char * orig,
                     char * rep,
                     char * with )
 {
-	char * result = NULL;
-	char * ins = NULL;
-	char * tmp = NULL;
-	int lenRep = 0;
-	int lenWith = 0;
-	int lenFront = 0;
-	int count = 0;
+    char * result = NULL;
+    char * ins = NULL;
+    char * tmp = NULL;
+    int lenRep = 0;
+    int lenWith = 0;
+    int lenFront = 0;
+    int count = 0;
 
-	if( !orig || !rep )
-	{
-		return NULL;
-	}
+    if( !orig || !rep )
+    {
+        return NULL;
+    }
 
-	lenRep = strlen( rep );
+    lenRep = strlen( rep );
 
-	if( lenRep == 0 )
-	{
-		return NULL;
-	}
+    if( lenRep == 0 )
+    {
+        return NULL;
+    }
 
-	if( !with )
-	{
-		with = "";
-	}
+    if( !with )
+    {
+        with = "";
+    }
 
-	lenWith = strlen( with );
-	ins = orig;
+    lenWith = strlen( with );
+    ins = orig;
 
-	for( count = 0; tmp = strstr( ins, rep ); ++count )
-	{
-		ins = tmp + lenRep;
-	}
+    for( count = 0; tmp = strstr( ins, rep ); ++count )
+    {
+        ins = tmp + lenRep;
+    }
 
-	tmp = result = pvPortMalloc( strlen( orig ) + ( lenWith - lenRep ) * count + 1 );
+    tmp = result = pvPortMalloc( strlen( orig ) + ( lenWith - lenRep ) * count + 1 );
 
-	if( !result )
-	{
-		return NULL;
-	}
+    if( !result )
+    {
+        return NULL;
+    }
 
-	while( count-- )
-	{
-		ins = strstr( orig, rep );
-		lenFront = ins - orig;
-		tmp = strncpy( tmp, orig, lenFront ) + lenFront;
-		tmp = strcpy( tmp, with ) + lenWith;
-		orig += lenFront + lenRep;
-	}
+    while( count-- )
+    {
+        ins = strstr( orig, rep );
+        lenFront = ins - orig;
+        tmp = strncpy( tmp, orig, lenFront ) + lenFront;
+        tmp = strcpy( tmp, with ) + lenWith;
+        orig += lenFront + lenRep;
+    }
 
-	strcpy( tmp, orig );
-	return result;
+    strcpy( tmp, orig );
+    return result;
 }
-
 /*-----------------------------------------------------------*/
 #ifdef democonfigRANGE_SIZE
 static int response_length( char* PART ) {
-	int pch = strstr( PART, "bytes" );
+    int pch = strstr( PART, "bytes" );
 
-	int rangeStart, rangeEnd, rangeOriginalSize;
-	if (3 == sscanf( pch,
+    int rangeStart, rangeEnd, rangeOriginalSize;
+    if (3 == sscanf( pch,
 	                 "%*[^0123456789]%d%*[^0123456789]%d%*[^0123456789]%d",
 	                 &rangeStart,
 	                 &rangeEnd,
-	                 &rangeOriginalSize));
-	return rangeOriginalSize;
+    	             &rangeOriginalSize));
+    return rangeOriginalSize;
 }
 /*-----------------------------------------------------------*/
 
 static uint8_t onboarding_request( uint8_t status, NetworkContext_t* pxNetworkContext, char** completeResponse ) {
-	char packetToSent[ 130 ];
-	int rangeStart = 0;
-	int rangeEnd = democonfigRANGE_SIZE;
-	int rangeOriginalSize;
-	memset( packetToSent, '\0', 130 * sizeof( char ) );
-	do {
-		sprintf(packetToSent, "GET /device-api/onboarding HTTP/1.1\r\n"
-		        "Host: %s\r\n"
-		        "Range: bytes=%d-%d\r\n"
+    char packetToSent[ 130 ];
+    int rangeStart = 0;
+    int rangeEnd = democonfigRANGE_SIZE;
+    int rangeOriginalSize;
+    memset( packetToSent, '\0', 130 * sizeof( char ) );
+    do {
+        sprintf(packetToSent, "GET /device-api/onboarding HTTP/1.1\r\n"
+                "Host: %s\r\n"
+                "Range: bytes=%d-%d\r\n"
 		        "Accept: text/csv\r\n\r\n", ONBOARDING_ENDPOINT, rangeStart, rangeEnd);
 		LogInfo( ( "Send onboarding request:\r\n%.*s",
 		           strlen(packetToSent),

--- a/source/demo_config.h
+++ b/source/demo_config.h
@@ -240,6 +240,6 @@
 /**
  * @brief Size of the range request from 1nce onboarding service.
  */
-#define democonfigRANGE_SIZE       ( 1000U )
+#define democonfigRANGE_SIZE                ( 1000U )
 
 #endif /* DEMO_CONFIG_H */

--- a/source/demo_config.h
+++ b/source/demo_config.h
@@ -237,4 +237,9 @@
  */
 #define democonfigNETWORK_BUFFER_SIZE       ( 1024U )
 
+/**
+ * @brief Size of the range request from 1nce onboarding service.
+ */
+#define democonfigRANGE_SIZE       ( 1000U )
+
 #endif /* DEMO_CONFIG_H */


### PR DESCRIPTION
Extend the demo for 1NCE zero touch provisioning to support splitting the response body into smaller chunks. This can be especially useful for devices with a small TLS buffer. 